### PR TITLE
Fix: Generate Entity PK on DB Insert 

### DIFF
--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Comment.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Comment.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeachersSideAPI.Domain.Models;
 
 public class Comment
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public Post Post { get; set; }
     public Teacher Creator { get; set; }
     public string Title { get; set; }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Event.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Event.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeachersSideAPI.Domain.Models;
 
 public class Event
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public Teacher Creator { get; set; }
     public string Title { get; set; }
     public string Description { get; set; }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Forum.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Forum.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeachersSideAPI.Domain.Models;
 
 public class Forum
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public Subject? Subject { get; set; }
     public List<Post> Posts { get; set; } = new List<Post>();
 }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Material.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Material.cs
@@ -1,10 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using TeachersSideAPI.Domain.Enums;
 
 namespace TeachersSideAPI.Domain.Models;
 
 public class Material
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public Subject Subject { get; set; }
     public Teacher Creator { get; set; }
     public DateTime DateCreated { get; set; }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Post.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Post.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeachersSideAPI.Domain.Models;
 
 public class Post
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public Forum Forum { get; set; }
     public Teacher Creator { get; set; }
     public string Title { get; set; }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Subject.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Domain/Models/Subject.cs
@@ -1,10 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using TeachersSideAPI.Domain.Enums;
 
 namespace TeachersSideAPI.Domain.Models;
 
 public class Subject
 {
-    public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
     public string Name { get; set; }
     public Category Category { get; set; }
     public List<Teacher> Teachers { get; set; }

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/20240302120630_Initial.Designer.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/20240302120630_Initial.Designer.cs
@@ -12,8 +12,8 @@ using TeachersSideAPI.Persistence;
 namespace TeachersSideAPI.Migrations
 {
     [DbContext(typeof(TeachersSideContext))]
-    [Migration("20231203123710_InitialMigration")]
-    partial class InitialMigration
+    [Migration("20240302120630_Initial")]
+    partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -26,11 +26,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("MaterialPost", b =>
                 {
-                    b.Property<Guid>("RelatedMaterialsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("RelatedMaterialsId")
+                        .HasColumnType("integer");
 
-                    b.Property<Guid>("RelatedPostsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("RelatedPostsId")
+                        .HasColumnType("integer");
 
                     b.HasKey("RelatedMaterialsId", "RelatedPostsId");
 
@@ -118,10 +118,12 @@ namespace TeachersSideAPI.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProviderKey")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("text");
@@ -158,10 +160,12 @@ namespace TeachersSideAPI.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Value")
                         .HasColumnType("text");
@@ -173,8 +177,8 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("SubjectTeacher", b =>
                 {
-                    b.Property<Guid>("SubjectsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("SubjectsId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("TeachersId")
                         .HasColumnType("text");
@@ -188,9 +192,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Comment", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Content")
                         .IsRequired()
@@ -205,8 +211,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<DateTime>("LastEdited")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("PostId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("PostId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("Title")
                         .IsRequired()
@@ -223,9 +229,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Event", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatorId")
                         .HasColumnType("text");
@@ -259,12 +267,14 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Forum", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
 
-                    b.Property<Guid>("SubjectId")
-                        .HasColumnType("uuid");
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<int?>("SubjectId")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -275,9 +285,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Material", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatorId")
                         .HasColumnType("text");
@@ -296,8 +308,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<int>("FileType")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("SubjectId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("SubjectId")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -310,9 +322,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Post", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Content")
                         .IsRequired()
@@ -324,8 +338,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<DateTime>("DateCreated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("ForumId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("ForumId")
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("LastEdited")
                         .HasColumnType("timestamp with time zone");
@@ -345,9 +359,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Subject", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<int>("Category")
                         .HasColumnType("integer");
@@ -544,9 +560,7 @@ namespace TeachersSideAPI.Migrations
                 {
                     b.HasOne("TeachersSideAPI.Domain.Models.Subject", "Subject")
                         .WithMany()
-                        .HasForeignKey("SubjectId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .HasForeignKey("SubjectId");
 
                     b.Navigation("Subject");
                 });

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/20240302120630_Initial.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/20240302120630_Initial.cs
@@ -6,7 +6,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace TeachersSideAPI.Migrations
 {
-    public partial class InitialMigration : Migration
+    public partial class Initial : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -55,7 +55,8 @@ namespace TeachersSideAPI.Migrations
                 name: "Subjects",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     Name = table.Column<string>(type: "text", nullable: false),
                     Category = table.Column<int>(type: "integer", nullable: false)
                 },
@@ -110,8 +111,8 @@ namespace TeachersSideAPI.Migrations
                 name: "AspNetUserLogins",
                 columns: table => new
                 {
-                    LoginProvider = table.Column<string>(type: "text", nullable: false),
-                    ProviderKey = table.Column<string>(type: "text", nullable: false),
+                    LoginProvider = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ProviderKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
                     ProviderDisplayName = table.Column<string>(type: "text", nullable: true),
                     UserId = table.Column<string>(type: "text", nullable: false)
                 },
@@ -155,8 +156,8 @@ namespace TeachersSideAPI.Migrations
                 columns: table => new
                 {
                     UserId = table.Column<string>(type: "text", nullable: false),
-                    LoginProvider = table.Column<string>(type: "text", nullable: false),
-                    Name = table.Column<string>(type: "text", nullable: false),
+                    LoginProvider = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
                     Value = table.Column<string>(type: "text", nullable: true)
                 },
                 constraints: table =>
@@ -174,7 +175,8 @@ namespace TeachersSideAPI.Migrations
                 name: "Events",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     CreatorId = table.Column<string>(type: "text", nullable: true),
                     Title = table.Column<string>(type: "text", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: false),
@@ -197,8 +199,9 @@ namespace TeachersSideAPI.Migrations
                 name: "Forums",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    SubjectId = table.Column<Guid>(type: "uuid", nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SubjectId = table.Column<int>(type: "integer", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -207,16 +210,16 @@ namespace TeachersSideAPI.Migrations
                         name: "FK_Forums_Subjects_SubjectId",
                         column: x => x.SubjectId,
                         principalTable: "Subjects",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        principalColumn: "Id");
                 });
 
             migrationBuilder.CreateTable(
                 name: "Materials",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    SubjectId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SubjectId = table.Column<int>(type: "integer", nullable: false),
                     CreatorId = table.Column<string>(type: "text", nullable: true),
                     DateCreated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     FileTitle = table.Column<string>(type: "text", nullable: false),
@@ -243,7 +246,7 @@ namespace TeachersSideAPI.Migrations
                 name: "SubjectTeacher",
                 columns: table => new
                 {
-                    SubjectsId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubjectsId = table.Column<int>(type: "integer", nullable: false),
                     TeachersId = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>
@@ -267,8 +270,9 @@ namespace TeachersSideAPI.Migrations
                 name: "Posts",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    ForumId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ForumId = table.Column<int>(type: "integer", nullable: false),
                     CreatorId = table.Column<string>(type: "text", nullable: true),
                     Title = table.Column<string>(type: "text", nullable: false),
                     Content = table.Column<string>(type: "text", nullable: false),
@@ -295,8 +299,9 @@ namespace TeachersSideAPI.Migrations
                 name: "Comments",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    PostId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PostId = table.Column<int>(type: "integer", nullable: false),
                     CreatorId = table.Column<string>(type: "text", nullable: true),
                     Title = table.Column<string>(type: "text", nullable: false),
                     Content = table.Column<string>(type: "text", nullable: false),
@@ -323,8 +328,8 @@ namespace TeachersSideAPI.Migrations
                 name: "MaterialPost",
                 columns: table => new
                 {
-                    RelatedMaterialsId = table.Column<Guid>(type: "uuid", nullable: false),
-                    RelatedPostsId = table.Column<Guid>(type: "uuid", nullable: false)
+                    RelatedMaterialsId = table.Column<int>(type: "integer", nullable: false),
+                    RelatedPostsId = table.Column<int>(type: "integer", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/TeachersSideContextModelSnapshot.cs
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/Migrations/TeachersSideContextModelSnapshot.cs
@@ -24,11 +24,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("MaterialPost", b =>
                 {
-                    b.Property<Guid>("RelatedMaterialsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("RelatedMaterialsId")
+                        .HasColumnType("integer");
 
-                    b.Property<Guid>("RelatedPostsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("RelatedPostsId")
+                        .HasColumnType("integer");
 
                     b.HasKey("RelatedMaterialsId", "RelatedPostsId");
 
@@ -116,10 +116,12 @@ namespace TeachersSideAPI.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProviderKey")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("text");
@@ -156,10 +158,12 @@ namespace TeachersSideAPI.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Value")
                         .HasColumnType("text");
@@ -171,8 +175,8 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("SubjectTeacher", b =>
                 {
-                    b.Property<Guid>("SubjectsId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("SubjectsId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("TeachersId")
                         .HasColumnType("text");
@@ -186,9 +190,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Comment", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Content")
                         .IsRequired()
@@ -203,8 +209,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<DateTime>("LastEdited")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("PostId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("PostId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("Title")
                         .IsRequired()
@@ -221,9 +227,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Event", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatorId")
                         .HasColumnType("text");
@@ -257,12 +265,14 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Forum", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
 
-                    b.Property<Guid>("SubjectId")
-                        .HasColumnType("uuid");
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<int?>("SubjectId")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -273,9 +283,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Material", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatorId")
                         .HasColumnType("text");
@@ -294,8 +306,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<int>("FileType")
                         .HasColumnType("integer");
 
-                    b.Property<Guid>("SubjectId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("SubjectId")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -308,9 +320,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Post", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Content")
                         .IsRequired()
@@ -322,8 +336,8 @@ namespace TeachersSideAPI.Migrations
                     b.Property<DateTime>("DateCreated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("ForumId")
-                        .HasColumnType("uuid");
+                    b.Property<int>("ForumId")
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("LastEdited")
                         .HasColumnType("timestamp with time zone");
@@ -343,9 +357,11 @@ namespace TeachersSideAPI.Migrations
 
             modelBuilder.Entity("TeachersSideAPI.Domain.Models.Subject", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<int>("Category")
                         .HasColumnType("integer");
@@ -542,9 +558,7 @@ namespace TeachersSideAPI.Migrations
                 {
                     b.HasOne("TeachersSideAPI.Domain.Models.Subject", "Subject")
                         .WithMany()
-                        .HasForeignKey("SubjectId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .HasForeignKey("SubjectId");
 
                     b.Navigation("Subject");
                 });

--- a/src/backend/TeachersSideAPI/TeachersSideAPI/TeachersSideAPI.csproj
+++ b/src/backend/TeachersSideAPI/TeachersSideAPI/TeachersSideAPI.csproj
@@ -18,4 +18,8 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Migrations\" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Changes:
- When a new entity is added to the DB the ID is autogenerated
- The ID is serial integer